### PR TITLE
Add Ruby 2.6 as a test target in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 before_install:
   - sudo apt-get install gcc make pkg-config clamav libclamav-dev clamav-freshclam
   - sudo freshclam


### PR DESCRIPTION
Ruby 2.6 was released 25th December 2018, which was after this Travis CI file was originally put together.